### PR TITLE
Use gradle-versions-plugin to check for dependency updates.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,10 @@ plugins {
     id "idea"
     id "org.jetbrains.intellij" version "0.4.13"
     id "com.github.johnrengelman.shadow" version "5.1.0"
+    id "com.github.ben-manes.versions" version "0.33.0"
 }
+
+apply from: "gradle/versions.gradle"
 
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,0 +1,14 @@
+// Gradle Versions Plugin
+
+tasks.named("dependencyUpdates").configure {
+    def isNonStable = { String version ->
+        def stableKeyword = ["RELEASE", "FINAL", "GA"].any {
+            qualifier -> version.toUpperCase().contains(qualifier)
+        }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+    rejectVersionIf {
+        isNonStable(it.candidate.version)
+    }
+}


### PR DESCRIPTION
# Description
+ This plugin adds the `dependencyUpdates` Gradle task.
+ Configure to only offer stable versions.
+ Plugin website: https://github.com/ben-manes/gradle-versions-plugin

# Command + example output

``` bash
$ ./gradlew dependencyUpdates
```

```
------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.33.0
 - commons-lang:commons-lang:2.6

The following dependencies have later milestone versions:
 - com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin [5.1.0 -> 6.1.0]
 - com.google.guava:guava [11.0.2 -> 23.0]
     https://github.com/google/guava
 - commons-io:commons-io [2.2 -> 2.8.0]
     https://commons.apache.org/proper/commons-io/
 - org.codehaus.groovy:groovy-backports-compat23 [2.3.9 -> 3.0.6]
     https://groovy-lang.org
 - org.gradle:gradle-tooling-api [5.6.2 -> 6.7]
 - org.jetbrains.intellij:org.jetbrains.intellij.gradle.plugin [0.4.13 -> 0.5.0]
 - org.slf4j:slf4j-simple [1.7.2 -> 1.7.30]
     http://www.slf4j.org

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.jetbrains:ideaIC

Gradle current updates:
 - Gradle: [5.6.2 -> 6.7]

Generated report file build/dependencyUpdates/report.txt
```